### PR TITLE
Fixes url to vim-slim repo

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -35,7 +35,7 @@
     au BufNewFile,BufRead *.mustache,*.handlebars,*.hbs set filetype=mustache
 
 " Slim
-  Bundle "git://github.com/bbommarito/vim-slim.git"
+  Bundle "git://github.com/slim-template/vim-slim.git"
     au BufNewFile,BufRead *.slim set filetype=slim
 
 " Less


### PR DESCRIPTION
The url has changed, this fixes it. Cheers.
