### PR TITLE
remove mapping that breaks jump-list navigation

### DIFF
--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -54,9 +54,6 @@
 " map spacebar to clear search highlight
   nnoremap <Leader><space> :noh<cr>
 
-" make tab key match bracket pairs
-  vnoremap <tab> %
-
 " buffer resizing mappings (shift + arrow key)
   nnoremap <S-Up> <c-w>+
   nnoremap <S-Down> <c-w>-


### PR DESCRIPTION
Vim's default behavior of <tab> and <C-I> is to move forward in the jumplist (`:help jump-motions`). This is a useful feature that we should not be breaking with custom mappings.
