### PR TITLE
Syntastic is too slow when saving HAML and SASS

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -159,7 +159,10 @@
   Bundle "git://github.com/scrooloose/syntastic.git"
     let g:syntastic_enable_signs=1
     let g:syntastic_quiet_warnings=1
-    let g:syntastic_disabled_filetypes = ['sass']
+    " syntastic is too slow for haml and sass
+    let g:syntastic_mode_map = { 'mode': 'active',
+                               \ 'active_filetypes': [],
+                               \ 'passive_filetypes': ['haml','scss','sass'] }
 
 
 " gist-vim for quickly creating gists


### PR DESCRIPTION
Also, I don't think the `g:syntastic_disabled_filetypes` setting is valid anymore.
