### PR TITLE
Add vim-css-color to vim-config

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -24,6 +24,7 @@
   Bundle "git://github.com/vim-scripts/ruby-matchit.git"
   Bundle "git://github.com/wgibbs/vim-irblack.git"
   Bundle "git://github.com/wavded/vim-stylus.git"
+  Bundle "git://github.com/skammer/vim-css-color.git"
 
   " CtrlP - with FuzzyFinder compatible keymaps
   Bundle "git://github.com/kien/ctrlp.vim.git"


### PR DESCRIPTION
This plugin highlights CSS colors inline, including hex, rgba and valid color names. I found it pretty helpful, especially when dealing with vendor CSS files.
