### PR TITLE
Replace Ack with the Silver Searcher (ag)

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -71,10 +71,19 @@
 
 
 " ACK
-  Bundle "git://github.com/mileszs/ack.vim.git"
-    nmap g/ :Ack!<space>
-    nmap g* :Ack! -w <C-R><C-W><space>
-    nmap ga :AckAdd!<space>
+" Bundle "git://github.com/mileszs/ack.vim.git"
+"   nmap g/ :Ack!<space>
+"   nmap g* :Ack! -w <C-R><C-W><space>
+"   nmap ga :AckAdd!<space>
+"   nmap gn :cnext<CR>
+"   nmap gp :cprev<CR>
+"   nmap gq :ccl<CR>
+"   nmap gl :cwindow<CR>
+
+" AG aka The Silver Searcher
+  Bundle 'git://github.com/rking/ag.vim.git'
+    nmap g/ :Ag!<space>
+    nmap ga :AgAdd!<space>
     nmap gn :cnext<CR>
     nmap gp :cprev<CR>
     nmap gq :ccl<CR>


### PR DESCRIPTION
This is simply a 'swap one for the other' topic branch. If we
collectively believe ag to be better perhaps we will want to have
everyone default to it vs ack. It requires users to install ag before
the plugin will work but the same is true for Ack on certain machines as
well.

I'll issue a pull request for team review but suspect we'll probably
just leave the topic branch for now and let folks merge their own
version of what tools they like. You can also manually install via
vundle and remap the ack commands in your personal config as well. This
is what I have been doing but feel like others would benefit from this
being in the core distro.
