### PR TITLE
Remove vim-css-color to avoid slow loading bug

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -24,9 +24,6 @@
   Bundle "git://github.com/vim-scripts/ruby-matchit.git"
   Bundle "git://github.com/wgibbs/vim-irblack.git"
   Bundle "git://github.com/wavded/vim-stylus.git"
-  " Bundle git://github.com/skammer/vim-css-color.git
-  " Use Aaron Baker's Fork to add SASS/SCSS color highlighting
-  Bundle "git@github.com:bakis2011/vim-css-color.git"
 
 " CtrlP - with FuzzyFinder compatible keymaps
   Bundle "git://github.com/kien/ctrlp.vim.git"


### PR DESCRIPTION
So it seems that vim-css-color was causing huge slow downs during file loading. I think that we can just remove the plugin as it's just a nicety
