### PR TITLE
fix syntastic warning

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -173,7 +173,7 @@
 " Syntastic for catching syntax errors on save
   Bundle "git://github.com/scrooloose/syntastic.git"
     let g:syntastic_enable_signs=1
-    let syntastic_quiet_messages = {'level': 'warning'}
+    let g:syntastic_quiet_messages = {'level': 'warning'}
     " syntastic is too slow for haml and sass
     let g:syntastic_mode_map = { 'mode': 'active',
                                \ 'active_filetypes': [],


### PR DESCRIPTION
Hey I updated my deps and I got this warning

``` shell
syntastic: warning: variable g:syntastic_quiet_warnings is deprecated, please use let g:syntastic_quiet_messages = {'level': 'warnings'} instead
```

So I fixed it, everything seems to work.
