### PR TITLE
change nerdtree toggle keybind

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -139,7 +139,7 @@
   Bundle "git://github.com/scrooloose/nerdtree.git"
     let NERDTreeHijackNetrw = 0
 
-    nmap gt :NERDTreeToggle<CR>
+    nmap <Leader>g :NERDTreeToggle<CR>
     nmap g :NERDTree \| NERDTreeToggle \| NERDTreeFind<CR>
 
 


### PR DESCRIPTION
I think we should avoid overriding any of the default vim keybinds, unless it is adding something that works similar to the original.

Something that has always bugged me is that the Neo vim-config changed **gt** to toggle NERDTree, rather than leaving it as the default **:tabnext**.

Does anyone else feel the same? I'll always run with this config in my own fork but I'd prefer not to have to!
