### PR TITLE
Fix vim-matchit repository link.

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -17,7 +17,7 @@
   Bundle "git://github.com/ervandew/supertab.git"
   Bundle "git://github.com/tomtom/tcomment_vim.git"
   Bundle "git://github.com/michaeljsmith/vim-indent-object.git"
-  Bundle "git://github.com/tsaleh/vim-matchit.git"
+  Bundle "git://github.com/vim-scripts/matchit.zip"
   Bundle "git://github.com/kana/vim-textobj-user.git"
   Bundle "git://github.com/nelstrom/vim-textobj-rubyblock.git"
   Bundle "git://github.com/tpope/vim-repeat.git"


### PR DESCRIPTION
Summary:
Plugin vim-matchit doesn't exist.

Description:
Repository for vim-matchit plugin on git://github.com/tsaleh/vim-matchit.git doesn't exist anymore, replaced the missing plugin with: https://github.com/vim-scripts/matchit.zip

Reference:
https://github.com/thoughtbot/dotfiles/issues/234
