### PR TITLE
removing duplicate paredit

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -218,7 +218,6 @@
 
 
 " Clojure Highlighting"
-  Bundle 'paredit.vim'
   let g:paredit_leader= '\'
   Bundle "git://github.com/tpope/vim-fireplace.git"
   Bundle "git://github.com/tpope/vim-classpath.git"


### PR DESCRIPTION
There are duplicate entries for paredit in the plugin_config file
