### PR TITLE
Remove redundant keybindings for fuzzy finder

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -53,17 +53,12 @@
     nmap <Leader>qa <Plug>DashGlobalSearch
 
 
-" CtrlP - with FuzzyFinder compatible keymaps
+" CtrlP
   Bundle "git://github.com/kien/ctrlp.vim.git"
     nnoremap <Leader>b :<C-U>CtrlPBuffer<CR>
     nnoremap <Leader>t :<C-U>CtrlP<CR>
     nnoremap <Leader>T :<C-U>CtrlPTag<CR>
-    let g:ctrlp_prompt_mappings = {
-        \ 'PrtSelectMove("j")':   ['<down>'],
-        \ 'PrtSelectMove("k")':   ['<up>'],
-        \ 'AcceptSelection("h")': ['<c-j>'],
-        \ 'AcceptSelection("v")': ['<c-k>', '<RightMouse>'],
-        \ }
+
     " respect the .gitignore
     let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others']
 


### PR DESCRIPTION
Some time in config history, CtrlP replaced FuzzyFinder. These were the
compatibility keybindings. However, CtrlP already has keys for these
commands.

Accept selection and open in vertical split: <c-v>
Accept selection and open in horizontal split: <c-s>

Let’s use those keys, so we can actually navigate the CtrlP window with
the standard vim home row keys!

Move up in the CtrlP selection window: <c-k>
Move down in the CtrlP selection window: <c-j>
