### PR TITLE
Fix nerdtree bindings

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -119,9 +119,8 @@
 " NERDTree for project drawer
   Bundle "git://github.com/scrooloose/nerdtree.git"
     let NERDTreeHijackNetrw = 0
-
-    nmap gt :NERDTreeToggle<CR>
-    nmap g :NERDTree \| NERDTreeToggle \| NERDTreeFind<CR>
+    nmap <leader>g :NERDTreeToggle<CR>
+    nmap <leader>G :NERDTreeFind<CR>
 
 
 " Tabular for aligning text


### PR DESCRIPTION
Does what https://github.com/neo/vim-config/pull/27 was trying to accomplish

leader g does nerdtree toggle (formerly g t)
leader G does nerdtree find (formerly g ctrl+t)
