### PR TITLE
Remove custom search bindings.

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -36,10 +36,6 @@
 
 " Easy motion config
   Bundle "git://github.com/Lokaltog/vim-easymotion.git"
-  map  / <Plug>(easymotion-sn)
-  omap / <Plug>(easymotion-tn)
-  map  n <Plug>(easymotion-next)
-  map  N <Plug>(easymotion-prev)
 
 "Supertab code completion"
   Bundle "git://github.com/ervandew/supertab.git"


### PR DESCRIPTION
We had overridden the default '/' behavior and it's maddening.
