### PR TITLE
Revert transparency default in gvimrc (per #43)

### DIFF
--- a/.gvimrc
+++ b/.gvimrc
@@ -8,9 +8,6 @@
   set guioptions-=r
   set guioptions-=L
 
-" transparency
-  set transparency=5
-
 " go full screen like you mean it
   if has('win32')
     au GUIEnter * simalt ~x


### PR DESCRIPTION
See discussion in #43. You can add this back for your own setup in custom_config.