### PR TITLE
Allow customizations prior to common config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vim/custom_config
+.vim/custom_preconfig

--- a/.vimrc
+++ b/.vimrc
@@ -1,6 +1,7 @@
 set rtp+=~/.vim/vundle.git/
 call vundle#rc()
 
+runtime! custom_preconfig/*.vim
 runtime! common_config/*.vim
 runtime! custom_config/*.vim
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Windows users: be sure to use **RailsInstaller** > **Command Prompt with Ruby an
 
 ## Customizing
 
-Customizations can be added to the folder `.vim/custom_config/`.
+Customizations can be added to the folder `.vim/custom_preconfig/` or `.vim/custom_config/`
 
 * Any files with a `.vim` extension in that folder will be loaded when running all versions of `vim`.
 * Any files with a `.gvim` extension in that folder will be loaded when running a graphical version of `vim`.
+
+The custom_preconfig settings are loaded prior to the common config. A common usecase for this is to reset mapleader.  Most of the rest of the customizations are placed in custom_config.
 
 You can add custom plugins by registering them in a `.vim` file in the custom_config folder with the same `Bundle "plugin-repo-url"`
 syntax used in the `.vim/common_config/plugin_config.vim`, and then performing steps 3 & 4 from the install steps above.


### PR DESCRIPTION
I want to use comma for mapleader instead of using backslash like an animal. But you have to set mapleader prior to actually using it. This allows you to have custom configurations that are run prior to the common config settings.