### PR TITLE
Load custom_config inside NeoBundle's environment

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -228,4 +228,7 @@
   nmap <Leader>rl :wa<CR> :call RunLastSpec()<CR>
   nmap <Leader>ra :wa<CR> :call RunAllSpecs()<CR>
 
+" Load custom config here so custom bundles can be installed
+  runtime! custom_config/*.vim
+
  call neobundle#end()

--- a/.vimrc
+++ b/.vimrc
@@ -2,7 +2,6 @@ set rtp+=~/.vim/bundle/neobundle.vim/
 
 runtime! custom_preconfig/*.vim
 runtime! common_config/*.vim
-runtime! custom_config/*.vim
 
 " for git, add spell checking and automatic wrapping at 72 columns
 autocmd Filetype gitcommit setlocal spell textwidth=72


### PR DESCRIPTION
Plugins must be defined within the `neobundle#begin` and `neobundle#end`
blocks, otherwise the NeoBundle directive won't be understood.
Additionally, it doesn't appear that you can define multiple NeoBundle
blocks - the last defined NeoBundle block appears to win.